### PR TITLE
feat: 장바구니에 아이템 추가 기능 추가 #ZU7-22

### DIFF
--- a/src/main/java/salute/oneshot/domain/cart/controller/CartController.java
+++ b/src/main/java/salute/oneshot/domain/cart/controller/CartController.java
@@ -1,0 +1,35 @@
+package salute.oneshot.domain.cart.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import salute.oneshot.domain.cart.dto.request.AddCartItemRequestDto;
+import salute.oneshot.domain.cart.dto.response.CartItemResponseDto;
+import salute.oneshot.domain.cart.dto.service.AddCartItemSDto;
+import salute.oneshot.domain.cart.service.CartService;
+import salute.oneshot.domain.common.dto.success.ApiResponse;
+import salute.oneshot.domain.common.dto.success.ApiResponseMessage;
+
+@RestController
+@RequestMapping("/api/carts")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping("/items")
+    public ResponseEntity<ApiResponse<CartItemResponseDto>> addItem(
+            @RequestBody AddCartItemRequestDto requestDto
+//            @AuthenticationPrincipal Long userId
+    ) {
+//        TODO: 시큐리티 설정
+        Long userId = 1L;
+
+        AddCartItemSDto sdto = AddCartItemSDto.of(userId, requestDto.getProductId(), requestDto.getAmount());
+        CartItemResponseDto responseDto = cartService.addCartItem(sdto);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(ApiResponseMessage.ADD_CART_ITEM_SUCCESS, responseDto)
+        );
+    }
+}

--- a/src/main/java/salute/oneshot/domain/cart/dto/request/AddCartItemRequestDto.java
+++ b/src/main/java/salute/oneshot/domain/cart/dto/request/AddCartItemRequestDto.java
@@ -1,0 +1,11 @@
+package salute.oneshot.domain.cart.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AddCartItemRequestDto {
+    private final Long productId;
+    private final Integer amount;
+}

--- a/src/main/java/salute/oneshot/domain/cart/dto/response/CartItemResponseDto.java
+++ b/src/main/java/salute/oneshot/domain/cart/dto/response/CartItemResponseDto.java
@@ -1,0 +1,22 @@
+package salute.oneshot.domain.cart.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import salute.oneshot.domain.cart.entity.CartItem;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CartItemResponseDto {
+    private final Long id;
+    private final Long productId;
+    private final Integer amount;
+
+    public static CartItemResponseDto from(CartItem item) {
+        return new CartItemResponseDto(
+                item.getId(),
+                item.getProduct().getId(),
+                item.getAmount()
+        );
+    }
+}

--- a/src/main/java/salute/oneshot/domain/cart/dto/response/CartResponseDto.java
+++ b/src/main/java/salute/oneshot/domain/cart/dto/response/CartResponseDto.java
@@ -1,0 +1,22 @@
+package salute.oneshot.domain.cart.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import salute.oneshot.domain.cart.entity.Cart;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CartResponseDto {
+
+    private final List<CartItemResponseDto> cartItemList;
+
+    public static CartResponseDto from(Cart cart) {
+        return new CartResponseDto(cart.getCartItemList()
+                .stream()
+                .map(CartItemResponseDto::from)
+                .toList());
+    }
+}

--- a/src/main/java/salute/oneshot/domain/cart/dto/service/AddCartItemSDto.java
+++ b/src/main/java/salute/oneshot/domain/cart/dto/service/AddCartItemSDto.java
@@ -1,0 +1,17 @@
+package salute.oneshot.domain.cart.dto.service;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AddCartItemSDto {
+    private final Long userId;
+    private final Long productId;
+    private final Integer amount;
+
+    public static AddCartItemSDto of(Long userId, Long productId, Integer amount) {
+        return new AddCartItemSDto(userId, productId, amount);
+    }
+}

--- a/src/main/java/salute/oneshot/domain/cart/entity/Cart.java
+++ b/src/main/java/salute/oneshot/domain/cart/entity/Cart.java
@@ -24,6 +24,7 @@ public class Cart extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    // Cart 엔티티를 불러오는 경우에 CartItemList를 불러오지 않는 경우가 없다고 판단하고 즉시 로딩으로 설정
     @OneToMany(mappedBy = "cart", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<CartItem> cartItemList;
 

--- a/src/main/java/salute/oneshot/domain/cart/entity/Cart.java
+++ b/src/main/java/salute/oneshot/domain/cart/entity/Cart.java
@@ -1,0 +1,37 @@
+package salute.oneshot.domain.cart.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import salute.oneshot.domain.common.dto.entity.BaseEntity;
+import salute.oneshot.domain.user.entity.User;
+
+import java.util.List;
+
+@Entity
+@Table(name = "carts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cart extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "BIGINT")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "cart", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CartItem> cartItemList;
+
+    public static Cart from(User user) {
+        return new Cart(user);
+    }
+
+    private Cart(User user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/salute/oneshot/domain/cart/entity/CartItem.java
+++ b/src/main/java/salute/oneshot/domain/cart/entity/CartItem.java
@@ -1,0 +1,39 @@
+package salute.oneshot.domain.cart.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import salute.oneshot.domain.product.entity.Product;
+
+@Entity
+@Table(name = "cart_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "BIGINT")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id")
+    private Cart cart;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private Integer amount;
+
+    private CartItem(Cart cart, Product product, Integer amount) {
+        this.cart = cart;
+        this.product = product;
+        this.amount = amount;
+    }
+
+    public static CartItem of(Cart foundCart, Product foundProduct, Integer amount) {
+        return new CartItem(foundCart, foundProduct, amount);
+    }
+}

--- a/src/main/java/salute/oneshot/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/salute/oneshot/domain/cart/repository/CartItemRepository.java
@@ -1,0 +1,9 @@
+package salute.oneshot.domain.cart.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import salute.oneshot.domain.cart.entity.Cart;
+import salute.oneshot.domain.cart.entity.CartItem;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+}

--- a/src/main/java/salute/oneshot/domain/cart/repository/CartRepository.java
+++ b/src/main/java/salute/oneshot/domain/cart/repository/CartRepository.java
@@ -1,0 +1,11 @@
+package salute.oneshot.domain.cart.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import salute.oneshot.domain.cart.entity.Cart;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    Optional<Cart> findByUserId(Long userId);
+}

--- a/src/main/java/salute/oneshot/domain/cart/service/CartService.java
+++ b/src/main/java/salute/oneshot/domain/cart/service/CartService.java
@@ -1,0 +1,42 @@
+package salute.oneshot.domain.cart.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import salute.oneshot.domain.cart.dto.response.CartItemResponseDto;
+import salute.oneshot.domain.cart.dto.service.AddCartItemSDto;
+import salute.oneshot.domain.cart.entity.Cart;
+import salute.oneshot.domain.cart.entity.CartItem;
+import salute.oneshot.domain.cart.repository.CartItemRepository;
+import salute.oneshot.domain.cart.repository.CartRepository;
+import salute.oneshot.domain.common.dto.error.ErrorCode;
+import salute.oneshot.domain.product.entity.Product;
+import salute.oneshot.domain.product.repository.ProductRepository;
+import salute.oneshot.domain.user.entity.User;
+import salute.oneshot.domain.user.repository.UserRepository;
+import salute.oneshot.global.exception.NotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public CartItemResponseDto addCartItem(AddCartItemSDto sdto) {
+        Cart foundCart = cartRepository.findByUserId(sdto.getUserId()).orElseGet(() -> {
+            User foundUser = userRepository.findById(sdto.getUserId()).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+            Cart newCart = Cart.from(foundUser);
+            return cartRepository.save(newCart);
+        });
+
+        Product foundProduct = productRepository.findById(sdto.getProductId()).orElseThrow(() -> new NotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
+        CartItem newItem = CartItem.of(foundCart, foundProduct, sdto.getAmount());
+        CartItem savedItem = cartItemRepository.save(newItem);
+
+        return CartItemResponseDto.from(savedItem);
+    }
+}

--- a/src/main/java/salute/oneshot/domain/common/dto/error/ErrorCode.java
+++ b/src/main/java/salute/oneshot/domain/common/dto/error/ErrorCode.java
@@ -24,7 +24,13 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."),
 
     // 팬트리 관련 익셉션
-    PANTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "팬트리가 존재하지 않습니다.");
+    PANTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "팬트리가 존재하지 않습니다."),
+
+    // 상품 관련 익셉션
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."),
+
+    // 장바구니 관련 익셉션
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "팬트리가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/salute/oneshot/domain/common/dto/error/ErrorCode.java
+++ b/src/main/java/salute/oneshot/domain/common/dto/error/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."),
 
     // 장바구니 관련 익셉션
-    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "팬트리가 존재하지 않습니다.");
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/salute/oneshot/domain/common/dto/success/ApiResponseMessage.java
+++ b/src/main/java/salute/oneshot/domain/common/dto/success/ApiResponseMessage.java
@@ -58,4 +58,9 @@ public class ApiResponseMessage {
     public static final String GET_FVRT_LIST_SUCCESS = "즐겨찾기 목록 조회가 완료되었습니다.";
     public static final String GET_FVRT_COUNT_SUCCESS = "레시피의 즐겨찾기 수 조회가 완료되었습니다.";
     public static final String DELETE_FVRT_SUCCESS = "즐겨찾기 해제가 완료되었습니다.";
+
+    // 장바구니 관련 메시지
+    public static final String ADD_CART_ITEM_SUCCESS = "장바구니 추가가 완료되었습니다.";
+    public static final String GET_CART_SUCCESS = "장바구니 조회가 완료되었습니다.";
+    public static final String EMPTY_CART_SUCCESS = "즐겨찾기 해제가 완료되었습니다.";
 }

--- a/src/main/java/salute/oneshot/domain/ingredientReview/controller/IngredientReviewController.java
+++ b/src/main/java/salute/oneshot/domain/ingredientReview/controller/IngredientReviewController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/ingredients")
+@RequestMapping("/api/ingredients/reviews")
 @RequiredArgsConstructor
 public class IngredientReviewController {
 

--- a/src/main/java/salute/oneshot/domain/product/entity/Product.java
+++ b/src/main/java/salute/oneshot/domain/product/entity/Product.java
@@ -1,0 +1,18 @@
+package salute.oneshot.domain.product.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "products")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "BIGINT")
+    private Long id;
+}

--- a/src/main/java/salute/oneshot/domain/product/repository/ProductRepository.java
+++ b/src/main/java/salute/oneshot/domain/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package salute.oneshot.domain.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import salute.oneshot.domain.product.entity.Product;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/salute/oneshot/domain/user/entity/User.java
+++ b/src/main/java/salute/oneshot/domain/user/entity/User.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 import salute.oneshot.domain.common.dto.entity.BaseEntity;
 
 @Entity
-@Table(name = "cocktails")
+@Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {


### PR DESCRIPTION
## #️⃣ Kan Board Number

7, 13

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 해당 유저의 장바구니가 존재하지 않는다면 장바구니 생성
2. 장바구니에 추가

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
1. Cart 엔티티를 불러오는 경우에 CartItemList를 불러오지 않는 경우는 없을 것 같다? -> 즉시로딩 FetchType.EAGER 사용해도 되는지
2. Cart에 User와 Product를 할당해줘야 하는데 엔티티의 id값만 필요함 -> findById 말고 existById + getRefernceById 쓰면 안되는지
3. AddItem 반환을 Cart로? 그냥 Item으로? -> 생성시 응답 데이터는 프론트를 편하게 하기 위해 -> 근데 AddItem의 경우 상품 페이지일텐데 의미가 있나? 통일성?
5. AddItem vs AddCartItem과 같이 이름 지을 때 통일성의 문제 -> 편의상 item으로 줄여서 해도 되는지

6. 카트는 나중에 최적화할 때 userId로 인덱싱 해두면 좋을 거 같다
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)
