### PR TITLE
feat: 본인 장바구니 조회 기능 추가 #ZU7-22

### DIFF
--- a/src/main/java/salute/oneshot/domain/cart/controller/CartController.java
+++ b/src/main/java/salute/oneshot/domain/cart/controller/CartController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import salute.oneshot.domain.cart.dto.request.AddCartItemRequestDto;
 import salute.oneshot.domain.cart.dto.response.CartItemResponseDto;
+import salute.oneshot.domain.cart.dto.response.CartResponseDto;
 import salute.oneshot.domain.cart.dto.service.AddCartItemSDto;
 import salute.oneshot.domain.cart.service.CartService;
 import salute.oneshot.domain.common.dto.success.ApiResponse;
@@ -22,7 +23,7 @@ public class CartController {
             @RequestBody AddCartItemRequestDto requestDto
 //            @AuthenticationPrincipal Long userId
     ) {
-//        TODO: 시큐리티 설정
+//        TODO: 시큐리티 설정 후 테스트용 데이터 지우기
         Long userId = 1L;
 
         AddCartItemSDto sdto = AddCartItemSDto.of(userId, requestDto.getProductId(), requestDto.getAmount());
@@ -30,6 +31,21 @@ public class CartController {
 
         return ResponseEntity.ok(
                 ApiResponse.success(ApiResponseMessage.ADD_CART_ITEM_SUCCESS, responseDto)
+        );
+    }
+
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CartResponseDto>> findCart(
+//            @AuthenticationPrincipal Long userId
+    ) {
+//        TODO: 시큐리티 설정 후 테스트용 데이터 지우기
+        Long userId = 1L;
+
+        CartResponseDto responseDto = cartService.findCart(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(ApiResponseMessage.GET_CART_SUCCESS, responseDto)
         );
     }
 }

--- a/src/main/java/salute/oneshot/domain/cart/dto/response/CartResponseDto.java
+++ b/src/main/java/salute/oneshot/domain/cart/dto/response/CartResponseDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import salute.oneshot.domain.cart.entity.Cart;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -18,5 +19,9 @@ public class CartResponseDto {
                 .stream()
                 .map(CartItemResponseDto::from)
                 .toList());
+    }
+
+    public static CartResponseDto empty(Long userId) {
+        return new CartResponseDto(new ArrayList<>());
     }
 }

--- a/src/main/java/salute/oneshot/domain/cart/service/CartService.java
+++ b/src/main/java/salute/oneshot/domain/cart/service/CartService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import salute.oneshot.domain.cart.dto.response.CartItemResponseDto;
+import salute.oneshot.domain.cart.dto.response.CartResponseDto;
 import salute.oneshot.domain.cart.dto.service.AddCartItemSDto;
 import salute.oneshot.domain.cart.entity.Cart;
 import salute.oneshot.domain.cart.entity.CartItem;
@@ -15,6 +16,8 @@ import salute.oneshot.domain.product.repository.ProductRepository;
 import salute.oneshot.domain.user.entity.User;
 import salute.oneshot.domain.user.repository.UserRepository;
 import salute.oneshot.global.exception.NotFoundException;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -38,5 +41,10 @@ public class CartService {
         CartItem savedItem = cartItemRepository.save(newItem);
 
         return CartItemResponseDto.from(savedItem);
+    }
+
+    public CartResponseDto findCart(Long userId) {
+        Optional<Cart> foundOptionalCart = cartRepository.findByUserId(userId);
+        return foundOptionalCart.map(CartResponseDto::from).orElseGet(() -> CartResponseDto.empty(userId));
     }
 }

--- a/src/main/java/salute/oneshot/domain/common/dto/error/ErrorCode.java
+++ b/src/main/java/salute/oneshot/domain/common/dto/error/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."),
 
     // 장바구니 관련 익셉션
-    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니가 존재하지 않습니다.");
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니가 존재하지 않습니다."),
   
     // 레시피 관련 익셉션
     RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "레시피가 존재하지 않습니다.");


### PR DESCRIPTION
## #️⃣ Kan Board Number

7, 22

## 📝 요약

- 본인 장바구니 조회 기능 추가
- 카트가 없는 경우 비어있는 리스트를 가진 responseDto를 반환

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)
