### PR TITLE
refactor: ResponseDto에 재료 이름 필드 추가 #ZU7-77

### DIFF
--- a/src/main/java/salute/oneshot/domain/ingredientReview/dto/response/IngrReviewResponseDto.java
+++ b/src/main/java/salute/oneshot/domain/ingredientReview/dto/response/IngrReviewResponseDto.java
@@ -8,6 +8,7 @@ import salute.oneshot.domain.ingredientReview.entity.IngredientReview;
 @AllArgsConstructor
 public class IngrReviewResponseDto {
 
+    private String ingredientName;
     private Long reviewId;
     private Byte star;
     private String content;
@@ -15,7 +16,7 @@ public class IngrReviewResponseDto {
 
     public static IngrReviewResponseDto from(IngredientReview ingredientReview) {
         return new IngrReviewResponseDto(
-                ingredientReview.getId(), ingredientReview.getStar(),
+                ingredientReview.getIngredient().getName(), ingredientReview.getId() ,ingredientReview.getStar(),
                 ingredientReview.getContent(), ingredientReview.getUser().getId());
     }
 

--- a/src/main/java/salute/oneshot/domain/ingredientReview/service/IngredientReviewService.java
+++ b/src/main/java/salute/oneshot/domain/ingredientReview/service/IngredientReviewService.java
@@ -59,6 +59,9 @@ public class IngredientReviewService {
 
     public Page<IngrReviewResponseDto> getAllIngredientReview(GetAllIngrReviewSDto sDto) {
 
+        Ingredient ingredient = ingredientRepository.findById(sDto.getIngredientId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.INGREDIENT_NOT_FOUND));
+
         Page<IngredientReview> ingredientReviewPage = ingredientReviewRepository
                 .findAllByIngredient_Id(sDto.getIngredientId(), sDto.getPageable());
 


### PR DESCRIPTION
## #️⃣ Kan Board Number

<!--- ex) #이슈번호, #이슈번호 -->
77
## 📝 요약
재료 리뷰 전체 조회 API에 재료 확인 로직 추가, ResponseDto에 재료 이름 필드 추가(https://github.com/KangSemin/oneshot/commit/bbe729d7865c13d5e99cf6e341728c5f62bce861)을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [ ] 커밋 메시지 컨벤션 준수
- [ ] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)
