### PR TITLE
refactof: nonce 생성 로직 중복제거 #ZU7-148

### DIFF
--- a/src/main/java/salute/oneshot/domain/address/controller/AddressController.java
+++ b/src/main/java/salute/oneshot/domain/address/controller/AddressController.java
@@ -20,7 +20,7 @@ import salute.oneshot.domain.address.dto.service.UpdateAddressSDto;
 import salute.oneshot.domain.address.service.AddressService;
 import salute.oneshot.domain.common.dto.success.ApiResponse;
 import salute.oneshot.domain.common.dto.success.ApiResponseConst;
-import salute.oneshot.global.security.entity.CustomUserDetails;
+import salute.oneshot.global.security.model.CustomUserDetails;
 
 @RestController
 @RequestMapping("/api/addresses")

--- a/src/main/java/salute/oneshot/domain/address/controller/AddressViewController.java
+++ b/src/main/java/salute/oneshot/domain/address/controller/AddressViewController.java
@@ -8,8 +8,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import salute.oneshot.domain.address.entity.Address;
 import salute.oneshot.domain.address.service.AddressService;
-import salute.oneshot.global.config.NonceGenerator;
-import salute.oneshot.global.security.entity.CustomUserDetails;
+import salute.oneshot.global.security.model.CustomUserDetails;
 
 @Controller
 @RequestMapping("/addresses")
@@ -17,11 +16,9 @@ import salute.oneshot.global.security.entity.CustomUserDetails;
 public class AddressViewController {
 
     private final AddressService addressService;
-    private final NonceGenerator nonceGenerator;
 
     @GetMapping
-    public String addressPage(Model model) {
-        model.addAttribute("scriptNonce", nonceGenerator.getNonce());
+    public String addressPage() {
 
         return "address/address-create";
     }
@@ -36,7 +33,6 @@ public class AddressViewController {
         Address address = addressService.getAddressByIdAndUserId(
                 addressId, userDetails.getId());
         model.addAttribute("address", address);
-        model.addAttribute("scriptNonce",nonceGenerator.getNonce());
 
         return "address/address-update";
     }

--- a/src/main/java/salute/oneshot/domain/auth/controller/AuthViewController.java
+++ b/src/main/java/salute/oneshot/domain/auth/controller/AuthViewController.java
@@ -5,25 +5,22 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import salute.oneshot.global.config.NonceGenerator;
+import salute.oneshot.global.util.NonceGenerator;
 
 @Controller
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthViewController {
 
-    private final NonceGenerator nonceGenerator;
 
     @GetMapping("/login")
-    public String loginPage(Model model) {
-        model.addAttribute("scriptNonce", nonceGenerator.getNonce());
+    public String loginPage() {
 
         return "auth/login";
     }
 
     @GetMapping("/signup")
-    public String signupPage(Model model) {
-        model.addAttribute("scriptNonce", nonceGenerator.getNonce());
+    public String signupPage() {
 
         return "auth/signup";
     }

--- a/src/main/java/salute/oneshot/domain/auth/controller/AuthViewController.java
+++ b/src/main/java/salute/oneshot/domain/auth/controller/AuthViewController.java
@@ -2,10 +2,8 @@ package salute.oneshot.domain.auth.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import salute.oneshot.global.util.NonceGenerator;
 
 @Controller
 @RequestMapping("/auth")

--- a/src/main/java/salute/oneshot/domain/user/controller/UserViewController.java
+++ b/src/main/java/salute/oneshot/domain/user/controller/UserViewController.java
@@ -3,10 +3,9 @@ package salute.oneshot.domain.user.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import salute.oneshot.global.config.NonceGenerator;
+import salute.oneshot.global.util.NonceGenerator;
 
 @Controller
 @RequestMapping("/user")
@@ -16,8 +15,7 @@ public class UserViewController {
     private final NonceGenerator nonceGenerator;
 
     @GetMapping("/my-page")
-    public String getMyPage(Model model) {
-        model.addAttribute("scriptNonce", nonceGenerator.getNonce());
+    public String getMyPage() {
 
         return "user/get-my-page";
     }
@@ -25,8 +23,7 @@ public class UserViewController {
     @PreAuthorize("isAuthenticated()")
 
     @GetMapping("/information")
-    public String updateUserInfo(Model model) {
-        model.addAttribute("scriptNonce", nonceGenerator.getNonce());
+    public String updateUserInfo() {
 
         return "user/update-user-info";
     }

--- a/src/main/java/salute/oneshot/global/config/WebConfig.java
+++ b/src/main/java/salute/oneshot/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package salute.oneshot.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import salute.oneshot.global.interceptor.NonceInterceptor;
+import salute.oneshot.global.util.NonceGenerator;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final NonceGenerator nonceGenerator;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new NonceInterceptor(nonceGenerator))
+                .addPathPatterns("/**")
+                .excludePathPatterns("/static/**");
+    }
+}

--- a/src/main/java/salute/oneshot/global/interceptor/NonceInterceptor.java
+++ b/src/main/java/salute/oneshot/global/interceptor/NonceInterceptor.java
@@ -1,0 +1,30 @@
+package salute.oneshot.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import salute.oneshot.global.util.NonceGenerator;
+
+@Component
+@RequiredArgsConstructor
+public class NonceInterceptor implements HandlerInterceptor {
+
+    private final NonceGenerator nonceGenerator;
+    @Override
+    public void postHandle(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull Object handler,
+            ModelAndView modelAndView
+    ) {
+        if (modelAndView != null) {
+            String nonce = (String) request.getAttribute("cspNonce");
+            modelAndView.addObject("scriptNonce", nonce);
+        }
+    }
+}

--- a/src/main/java/salute/oneshot/global/security/filter/CspNonceFilter.java
+++ b/src/main/java/salute/oneshot/global/security/filter/CspNonceFilter.java
@@ -1,0 +1,37 @@
+package salute.oneshot.global.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import salute.oneshot.global.security.model.SecurityConst;
+import salute.oneshot.global.util.NonceGenerator;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CspNonceFilter extends OncePerRequestFilter {
+
+    private final NonceGenerator nonceGenerator;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String nonce = nonceGenerator.getNonce();
+
+        request.setAttribute("cspNonce", nonce);
+
+        response.setHeader("Content-Security-Policy",
+                SecurityConst.CSP.buildFullPolicy(nonce));
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/salute/oneshot/global/security/model/SecurityConst.java
+++ b/src/main/java/salute/oneshot/global/security/model/SecurityConst.java
@@ -26,7 +26,7 @@ public class SecurityConst {
         public static final String SCRIPT_SRC_TOSS = "https://js.tosspayments.com https://log.tosspayments.com";
         public static final String SCRIPT_SRC_CDNJS = "https://cdnjs.cloudflare.com";
         public static final String SCRIPT_SRC_OAUTH2 = "https://accounts.google.com https://static.nid.naver.com";
-
+        public static final String SCRIPT_SRC_BOOTSTRAP = "https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com";
         // 프레임 소스
         public static final String FRAME_SRC_SELF = "'self'";
         public static final String FRAME_SRC_DAUM = "http://postcode.map.daum.net";
@@ -38,6 +38,7 @@ public class SecurityConst {
         public static final String STYLE_SRC_UNSAFE_INLINE = "'unsafe-inline'";
         public static final String STYLE_SRC_GOOGLE_FONTS = "https://fonts.googleapis.com";
         public static final String STYLE_SRC_OAUTH2 = "https://accounts.google.com https://nid.naver.com";
+        public static final String STYLE_SRC_BOOTSTRAP = "https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com";
 
         // 폰트 소스
         public static final String FONT_SRC_SELF = "'self'";
@@ -59,12 +60,13 @@ public class SecurityConst {
 
         // CSP 정책 생성 메서드
         public static String buildScriptSrcPolicy(String nonce) {
-            return String.format("script-src %s %s %s %s %s 'nonce-%s';",
+            return String.format("script-src %s %s %s %s %s %s 'nonce-%s';",
                     SCRIPT_SRC_SELF,
                     SCRIPT_SRC_DAUM,
                     SCRIPT_SRC_TOSS,
                     SCRIPT_SRC_CDNJS,
                     SCRIPT_SRC_OAUTH2,
+                    SCRIPT_SRC_BOOTSTRAP,
                     nonce);
         }
 
@@ -77,11 +79,12 @@ public class SecurityConst {
         }
 
         public static String buildStyleSrcPolicy() {
-            return String.format("style-src %s %s %s %s;",
+            return String.format("style-src %s %s %s %s %s;",
                     STYLE_SRC_SELF,
                     STYLE_SRC_UNSAFE_INLINE,
                     STYLE_SRC_GOOGLE_FONTS,
-                    STYLE_SRC_OAUTH2);
+                    STYLE_SRC_OAUTH2,
+                    STYLE_SRC_BOOTSTRAP);
         }
 
         public static String buildFontSrcPolicy() {

--- a/src/main/java/salute/oneshot/global/util/NonceGenerator.java
+++ b/src/main/java/salute/oneshot/global/util/NonceGenerator.java
@@ -1,4 +1,4 @@
-package salute.oneshot.global.config;
+package salute.oneshot.global.util;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +13,7 @@ import java.util.Base64;
 @RequiredArgsConstructor
 public class NonceGenerator {
 
-    private final String nonce;
-
-    public NonceGenerator() {
-        this.nonce = generateNonce();
-    }
-
-    private String generateNonce() {
+    public String getNonce() {
         try {
             return Base64.getEncoder().encodeToString(
                     SecureRandom.getInstance("SHA1PRNG").generateSeed(16)


### PR DESCRIPTION
## #️⃣ Kan Board Number

148

## 📝 요약

Spring MVC의 Model 객체:

컨트롤러에서 뷰로 데이터를 전달하기 위한 맵 형태의 컨테이너
주로 key-value 쌍의 형태로 데이터를 담아 뷰 템플릿으로 전달하는 역할
실제로는 MVC 패턴의 Model보다는 View와 Controller 사이의 데이터 전송 매개체

MVC 패턴의 "Model":

애플리케이션의 데이터와 비즈니스 로직을 담당하는 컴포넌트
도메인 객체, 서비스 객체, 레포지토리 등을 포함
데이터의 상태 변경, 데이터 유효성 검증, 비즈니스 규칙 적용 등을 담당

따라서 Model객체와 Model컴포넌트는 별개의 역할
하지만, nonce를 뷰로 전달하는 로직이 모든 컨트롤러에서 중복되므로
인터셉터, 필터를 사용해서 뷰로 nonce를 전달, 이로 중복 제거

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)
